### PR TITLE
Add integer_cast for unsigned int

### DIFF
--- a/include/zisa/utils/integer_cast.hpp
+++ b/include/zisa/utils/integer_cast.hpp
@@ -9,8 +9,8 @@ namespace zisa {
 namespace detail {
 template <class To, class From>
 class IntegerCast {
-  static_assert(!std::is_same<To, To>::value,
-      "zisa::IntegerCast is not specialized for the given input types");
+  static_assert(true,
+      "zisa::detail::IntegerCast is not specialized for the given input types");
 };
 
 template <>

--- a/test/zisa/unit_test/CMakeLists.txt
+++ b/test/zisa/unit_test/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_subdirectory(math)
+add_subdirectory(utils)

--- a/test/zisa/unit_test/utils/CMakeLists.txt
+++ b/test/zisa/unit_test/utils/CMakeLists.txt
@@ -1,0 +1,4 @@
+target_sources(core_unit_tests
+  PRIVATE ${CMAKE_CURRENT_LIST_DIR}/integer_cast.cpp
+)
+

--- a/test/zisa/unit_test/utils/integer_cast.cpp
+++ b/test/zisa/unit_test/utils/integer_cast.cpp
@@ -1,0 +1,43 @@
+#include <zisa/testing/testing_framework.hpp>
+
+#include <zisa/utils/integer_cast.hpp>
+
+TEST_CASE("integer_cast; API", "[utils]") {
+  int i_int = 32;
+  unsigned long i_ul = 32ul;
+  std::size_t i_size_t = 32;
+  std::size_t i_int_t = 32;
+
+  SECTION("int -> *") {
+    zisa::integer_cast<int>(i_int);
+    zisa::integer_cast<std::size_t>(i_int);
+    zisa::integer_cast<zisa::int_t>(i_int);
+    zisa::integer_cast<unsigned long>(i_int);
+  }
+
+  SECTION("unsigned long -> *") {
+    zisa::integer_cast<int>(i_ul);
+    zisa::integer_cast<std::size_t>(i_ul);
+    zisa::integer_cast<zisa::int_t>(i_ul);
+    zisa::integer_cast<unsigned long>(i_ul);
+  }
+
+  SECTION("zisa::size_t -> *") {
+    zisa::integer_cast<int>(i_size_t);
+    zisa::integer_cast<std::size_t>(i_size_t);
+    zisa::integer_cast<zisa::int_t>(i_size_t);
+    zisa::integer_cast<unsigned long>(i_size_t);
+  }
+
+  SECTION("unsigned long -> *") {
+    zisa::integer_cast<int>(i_int_t);
+    zisa::integer_cast<std::size_t>(i_int_t);
+    zisa::integer_cast<zisa::int_t>(i_int_t);
+    zisa::integer_cast<unsigned long>(i_int_t);
+  }
+
+  SECTION("unsigned long -> *") {
+    // Doesn't and shouldn't compile until `short` it's implemented for short.
+    //  zisa::integer_cast<short>(i_int_t);
+  }
+}


### PR DESCRIPTION
This PR adds a specialization for `zisa::integer_cast` for `size_t` and `unsigned int`. Additionally, a static assertion triggers when one tries to use `zisa::integer_cast` for types which it is not specialized for.